### PR TITLE
feat: allow skip parsing USE statement in run()

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,9 +2,12 @@ use crate::myc::constants::{CapabilityFlags, Command as CommandByte};
 
 #[derive(Debug)]
 pub struct ClientHandshake {
+    #[allow(dead_code)]
     maxps: u32,
     pub(crate) capabilities: CapabilityFlags,
+    #[allow(dead_code)]
     pub(crate) collation: u16,
+    #[allow(dead_code)]
     pub(crate) db: Option<Vec<u8>>,
     pub(crate) username: Vec<u8>,
     pub(crate) auth_response: Vec<u8>,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -115,8 +115,8 @@ impl<R: Read> PacketReader<R> {
             let end = self.bytes.len();
             self.bytes.resize(std::cmp::max(4096, end * 2), 0);
             let read = {
-                let mut buf = &mut self.bytes[end..];
-                self.r.read(&mut buf)?
+                let buf = &mut self.bytes[end..];
+                self.r.read(buf)?
             };
             self.bytes.truncate(end + read);
             self.remaining = self.bytes.len();


### PR DESCRIPTION
sometimes we wanna extend the SQL syntax like `USE WAREHOUSE xxx`, but in the MysqlIntermediary::run function, it preprocessed USE statement as starts_with("USE ") and pass the parsed database name to on_init(), causing we can not extend the USE XXX SQL syntax.

this commit adds a `process_use_statement_on_query` option to MysqlIntermediary struct and a MysqlIntermediaryOptions struct which allows us passing extra options into MysqlIntermediary.